### PR TITLE
chore: sync backend package-lock (axios bump)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "banknifty-signals-backend",
       "version": "1.0.0",
       "dependencies": {
-        "axios": "^1.11.0",
+        "axios": "^1.12.0",
         "cors": "2.8.5",
         "crypto-js": "4.2.0",
         "dotenv": "16.3.1",
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",


### PR DESCRIPTION
Sync backend/package-lock.json to match package.json bump of axios to 1.12.0 so CI 
pm ci succeeds.