### PR TITLE
docs: split RULES into smaller files and add defaults.json

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,101 @@
+
+```markdown
+---
+project_name: banknifty-signals
+---
+
+# PROJECT_PLAN.md
+
+## 1. Goals & Scope
+- Deliver a **production-ready trading workstation** with:
+  - Zerodha live integration (BANKNIFTY + NIFTY + top 10 banks).
+  - Real-time BUY/SELL signals from 47+ rules and the News Sentiment Analysis
+  - Live dashboard with charts, tooltips, and multi-timeframe signals.
+  - Backtesting module with visualization & exports.
+  - Sentiment integration.
+  - Robust persistence (PostgreSQL, Redis).
+  - Full observability (Prometheus + Grafana).
+  - Local single-user deployment via Docker.
+
+## 2. Architecture
+### Frontend
+- React + Vite, TailwindCSS + shadcn/ui.
+- TradingView lightweight-charts v4.1.0.
+- Socket.IO client.
+- Pages: Dashboard, Backtesting, Sentiment, Rules Engine, Settings.
+
+### Backend
+- Node.js + Express + Socket.IO.
+- Modules:
+  - Zerodha adapter (REST + WS, OAuth lifecycle).
+  - Rules Engine (47 rules, persisted configs).
+  - Signal Generator.
+  - Backtester (walk-forward, grid, Monte Carlo).
+  - Sentiment Engine (Webz.io, Tiingo, Alpha Vantage).
+- PostgreSQL (Prisma/TypeORM schema + migrations).
+- Redis for caching/pubsub.
+- Config: `.env` with schema validation.
+- Observability: Prometheus `/metrics`, JSON structured logs.
+
+### Database Schema
+- `candles`, `signals`, `settings`, `sentiment_daily`, `snapshots`.
+- Redis keys for ticks, candles, rules, rate limits, job locks.
+
+## 3. Workflows
+- **Live data**: Zerodha WS → backend → rules engine → signals → frontend chart.
+- **Backtesting**: Historical candle ingestion → rules engine → metrics → visualization.
+- **Sentiment**: Daily fetch → DB persist → optional filter in rules.
+- **Export/Import**: Rule configs and backtest results as JSON/CSV.
+
+## 4. Build Stages & Milestones
+| Stage | Deliverables
+|-------|--------------|--------|
+| Base Infrastructure | Docker stack, Postgres, Redis, migrations, backend healthcheck
+| Zerodha Integration | OAuth, WS adapter, live ticks 
+| Rules Engine | Implement 47 rules, config persistence
+| Signal Generation | Signal storage, WS broadcast, DB persistence
+| Frontend Dashboard | Chart, rules panel, tooltips, signal feed
+| Backtesting Module | Modes, metrics, visualization, export
+| Sentiment Module | API fetch, integration, toggle in UI
+| Observability & Tests | Prometheus, logging, CI/CD, integration tests
+
+## 5. Dependencies
+- Zerodha KiteConnect API (REST + WS).
+- PostgreSQL 14+.
+- Redis 6+.
+- Node.js 18+ / React 18+.
+- Prometheus + Grafana.
+
+## 6. Risks
+| Risk | Mitigation |
+|------|------------|
+| Zerodha API limits | Rate-limiting, caching, graceful degradation |
+| OI data unavailable | Disable OI-dependent rules, show inactive |
+| Redis/DB downtime | Graceful shutdown + retries |
+| High latency | Local caching, efficient WebSocket handling |
+| Rule complexity (47+) | Modular rules, per-rule tests |
+
+## 7. CI/CD & Testing
+- Local testing before GitHub push:
+  - **Unit tests**: indicators, rules, metrics.
+  - **Integration tests**: Zerodha adapter, signal flow.
+  - **Smoke tests**: full stack spin-up.
+- GitHub Actions pipeline:
+  - Lint + tests → Docker build → push to registry → deploy.
+
+## 8. Deployment Checklist
+- [ ] Configure `.env` with API keys and DB URLs.
+- [ ] Run migrations + seeders.
+- [ ] Start full stack via `docker compose up`.
+- [ ] Verify backend healthcheck `/health`.
+- [ ] Connect Zerodha via Settings page.
+- [ ] Verify chart + live signals.
+
+## 9. Design Rationale
+- **Dockerized stack** for reproducibility.
+- **React + lightweight-charts** for performance.
+- **47 modular rules** for flexibility + tuning.
+- **PostgreSQL + Redis** for durability and speed.
+- **Prometheus/Grafana** for real-time monitoring.
+- **Single-user local app** reduces security surface.
+

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,261 @@
+---
+project_name: banknifty-signals
+---
+
+# RULES.md
+
+## Overview
+This file contains all **trading rules ** used in the **banknifty-signals** .  
+Each rule has:
+- **Title**
+- **Logic/Description**
+- **Tunables**
+- **Tests**
+
+Rules are **modular, configurable, and persisted** in DB.  
+Indicators from `utils/indicators.ts` and Sentiment filters are integrated.
+
+---
+
+> Defaults: see `config/defaults.json` for example tunable values and safe starting defaults.
+
+
+## 1. Rule Categories
+- **Trend / Structure**
+- **Momentum**
+- **Volume / Internals**
+- **Options / OI**
+- **Risk / Volatility**
+- **Pattern / Price Action**
+- **Sentiment**
+- **Execution / Guardrails**
+
+---
+
+## Rulebook (split into smaller docs)
+
+To make the rulebook easier to navigate and maintain we split the full list into multiple files under `docs/rules/`.
+
+- Part 1 (rules 1–12): `docs/rules/part-1.md`
+- Part 2 (rules 13–24): `docs/rules/part-2.md`
+- Part 3 (rules 25–36): `docs/rules/part-3.md`
+- Part 4 (rules 37–47 + Utils): `docs/rules/part-4.md`
+
+Global note: All rules must produce intraday signals for BANKNIFTY at 3-minute, 5-minute and 15-minute rolled intervals (server collects 1m base -> rollups to 3/5/15). Signals are only valid during trading hours 09:15–15:30 IST & for backtesting purposes.
+
+> If you want, I can open a PR that moves the split files into a `docs/` folder and updates references across the repo.
+
+13. ivCrushRule
+
+• Logic: Detect rapid implied volatility (IV) collapse after scheduled events and annotate signals (or reduce option-related signals) for intraday windows.
+• Tunables: iv_drop_pct, iv_lookback, event_cooldown_minutes.
+• Tests: Simulate IV drop events and confirm annotation, and that option/OI rules are suppressed or adjusted.
+
+14. liquidityGrabRule
+
+• Logic: Identify sharp price spike through liquidity cluster (wick through HVN) followed by quick reversal — classify as liquidity grab and issue contrarian signal if confirmed.
+• Tunables: wick_to_body_ratio, liquidity_cluster_sensitivity, max_reversion_bars.
+• Tests: Validate detection of liquidity grabs and confirm reversal probability vs random spikes.
+
+15. macdCrossRule
+
+• Logic: Use MACD line / signal cross with histogram momentum & optional volume to issue momentum-confirmed intraday signals on rollups.
+• Tunables: fast_len, slow_len, signal_len, min_hist_slope, volume_confirm.
+• Tests: Test cross with rising/falling histogram slope and ensure cross in chop is filtered.
+
+16. marketProfileRule
+
+• Logic: Derive POC/VAH/VAL from intraday profile; use value-area acceptance/rejection and POC changes as signal triggers on aggregated bars.
+• Tunables: profile_interval_minutes, value_area_pct, poc_sensitivity.
+• Tests: Confirm reactions at POC/VAH/VAL and ensure rejections produce expected signal behavior.
+
+17. marketThrustRule
+
+• Logic: Detect high-magnitude thrust moves (price + volume + momentum) and follow-through; emit trade signal when thrust crosses thresholds.
+• Tunables: thrust_threshold_pct, volume_multiplier, momentum_roc_len.
+• Tests: Validate thrust detection vs exhaustion and follow-through probability.
+
+18. meanReversionRule
+
+• Logic: Identify overextensions from short-term mean and emit contrarian intraday signals when reversion conditions + low regime volatility met.
+• Tunables: mean_len, deviation_threshold_pct, volatility_filter_atr.
+• Tests: Check reversion hits in range markets and suppressed firing in strong trends.
+
+19. momentumDivergenceRule
+
+• Logic: Detect divergence between momentum indicator (ROC/RSI) and price (new high/low) and use as reversal signal for intraday rollups.
+• Tunables: momentum_len, divergence_window, min_divergence_strength.
+• Tests: Validate detection of classic divergence and check false positives in sustained trends.
+
+20. momentumThresholdRule
+
+• Logic: Only allow signals when momentum metric exceeds threshold (filters weak momentum in chop) for 3/5/15m signals.
+• Tunables: momentum_metric, threshold_value, adaptive_scaling.
+• Tests: Ensure signals suppressed below threshold and allowed above, across varied vol days.
+
+21. openingRangeBreakoutRule
+
+• Logic: Use opening range (first N minutes) high/low break as trade trigger if breakout volume and subsequent follow-through confirm on aggregated bars.
+• Tunables: range_window_mins, breakout_threshold_pct, min_follow_through_bars.
+• Tests: Simulate ORB continuation vs false-breakout and confirm correct signal emission.
+
+22. optionFlowRule
+
+• Logic: Detect unusual option flow (large notional, directional call/put buys) and bias underlying intraday signals when flow correlates with price.
+• Tunables: min_notional, time_window_secs, flow_bias_confidence.
+• Tests: Validate that large flows precede directional moves and rule annotates/weights signals accordingly.
+
+23. optionGreeksRule
+
+• Logic: Monitor aggregated Greeks exposure (gamma/vega) that indicate sensitivity to underlying moves and adjust option-sensitive signals intraday.
+• Tunables: greek_thresholds (gamma, vega), exposure_window.
+• Tests: Ensure rule flags high gamma/vega periods and that option-flow signals adapt.
+
+24. orderflowDeltaRule
+
+• Logic: Use net orderflow delta (buy vs sell prints) to bias or confirm signals — emit when delta normalized over lookback exceeds threshold.
+• Tunables: delta_threshold, normalization_window, smoothing.
+• Tests: Confirm delta leads price moves and that normalized delta above threshold raises confidence.
+
+25. preMarketMomentumRule
+
+• Logic: Capture pre-market futures/early session momentum and bias first-hour intraday signals consistent with that pre-open trend.
+• Tunables: premarket_window_minutes, min_premarket_move_pct, apply_for_bars.
+• Tests: Validate premarket move predictive power for open + early intraday signals.
+
+26. roundNumberMagnetRule
+
+• Logic: Treat round strike/price levels as magnet/support-resistance; generate bounce or breakout signals when price approaches and reacts within tolerance.
+• Tunables: round_interval, tolerance_pct, reaction_window_bars.
+• Tests: Measure bounce vs break frequency at levels and validate event triggers.
+
+27. rsiAdaptiveRule
+
+• Logic: Adjust RSI overbought/oversold thresholds dynamically based on volatility regime (ATR); emit signals when adaptive thresholds crossed.
+• Tunables: rsi_len, base_upper, base_lower, volatility_adjustment_factor.
+• Tests: Check threshold shifting by ATR and verify stable signal count across regimes.
+
+28. sectorRotationRule
+
+• Logic: Use relative strength of Bank sector vs broader market or constituents to bias or suppress intraday signals.
+• Tunables: sector_window, rotation_threshold, weighting_mode.
+• Tests: Validate detection of sector rotation and that biases improve directional accuracy.
+
+29. spreadGuardRule
+
+• Logic: Detect wide bid-ask spreads and down-weight or block signals to avoid poor execution.
+• Tunables: max_spread_ticks, min_liquidity_volume, action (block|downweight).
+• Tests: Simulate wide spread scenarios and ensure signals are blocked or lowered in confidence.
+
+30. stochasticRule
+
+• Logic: Use Stochastic %K/%D crossings in context of trend to issue intraday entries at 3/5/15m when confluence present.
+• Tunables: k_len, d_len, overbought, oversold, trend_filter.
+• Tests: Validate cross triggers in trend vs range and false positive suppression.
+
+31. supertrendRule
+
+• Logic: Use SuperTrend flips (ATR-based) for directional bias and first-pullback entries on flip; issue signals at rollups.
+• Tunables: atr_len, multiplier, pullback_depth_atr.
+• Tests: Confirm flip detection and test pullback entries after flip.
+
+32. swingBreakRule
+
+• Logic: Detect clean break of recent swing high/low with confirmation volume and momentum for intraday rollout signals.
+• Tunables: swing_window, min_confirm_volume_z, momentum_confirm_len.
+• Tests: Validate swing-break success rate and avoid fake-break filter.
+
+33. threeBarThrustRule
+
+• Logic: Detect 3-bar thrust (consecutive strong closes with increasing range) and follow on momentum for intraday trades.
+• Tunables: bars=3, min_range_growth_pct, vol_filter_z.
+• Tests: Confirm pattern detection and test continuation vs exhaustion.
+
+34. timePatternRule
+
+• Logic: Identify repeating intraday time-of-day patterns (e.g., end-of-hour liquidity moves) and bias signals when pattern matched.
+• Tunables: session_window, pattern_library, match_confidence.
+• Tests: Verify repeatability across multiple sessions and correct detection of pattern-triggered signal bias.
+
+35. trendHTFRule
+
+• Logic: Use higher timeframe trend (5/15/60m) to bias 3/5/15m signals — require HTF confluence for higher conviction.
+• Tunables: htf_windows, confluence_required_count, htf_weight.
+• Tests: Multi-timeframe confluence tests and suppression when HTF disagrees.
+
+36. trendlineBreakRule
+
+• Logic: Auto-fit trendlines to pivots; signal on confirmed breakout with min touchpoints and volume confirmation at 3/5/15m.
+• Tunables: min_touch_points, break_buffer_pct, min_break_volume_z.
+• Tests: Differentiate valid trendline breaks vs false ones and confirm volume requirement prevents fakes.
+
+37. volatilityExpansionRule
+
+• Logic: Detect sudden volatility expansion (ATR or BB width jump) that often precedes directional moves and trigger momentum-follow signals.
+• Tunables: expansion_threshold_pct, vol_window, min_follow_through_bars.
+• Tests: Confirm expansions precede directional moves and test signal timing after expansion.
+
+38. volumeBalanceRule
+
+• Logic: Compare buy vs sell volume balance; emit signals when imbalance sustained and aligns with price action on rollups.
+• Tunables: balance_threshold_pct, normalization_window, smoothing.
+• Tests: Validate imbalance lead/lag and alignment with price movement.
+
+39. volumeClimaxRule
+
+• Logic: Detect volume climax (extreme volume zscore) often indicating exhaustion or start of thrust; classify as reversal or continuation based on context.
+• Tunables: climax_z_threshold, relative_vol_window, post_climax_window.
+• Tests: Validate exhaustion vs continuation labeling and subsequent price behavior.
+
+40. volumeProfileRule
+
+• Logic: Use intraday volume profile HVN/LVN to detect rejections or breakouts and trigger signals when price interacts with profile levels.
+• Tunables: profile_window_mins, hvn_lvn_threshold, rejection_confirmation_bars.
+• Tests: Confirm bounce/rejection at HVN/LVN and measure signal hit rates.
+
+41. vwapBiasRule
+
+• Logic: Use session VWAP and bands; emit BUY when price sustained above VWAP band and SELL when below, with rollup confirmations.
+• Tunables: vwap_band_sigma, sustain_bars_required, vwap_timeout_minutes.
+• Tests: Check bounce/rejection stats at VWAP and that sustaining above/below band increases confidence.
+
+42. wickRejectionRule
+
+• Logic: Detect strong wick rejection from key level (long tail with close away) and emit contrarian intraday signals when supported by volume.
+• Tunables: wick_to_body_ratio, key_level_filter, min_volume_z.
+• Tests: Validate rejection leads to reversal for a high % and ensure rule suppressed in low-volume contexts.
+
+Meta Rules (Regime / Composite Layer)
+43. regimeDetectionRule
+
+• Logic: Classify market regime (Trending / Range / Mean-Revert) using volatility, H/L overlap, ADX, BB bandwidth and recent breakout success rate; smooth transitions.
+• Tunables: regime_window, feature_set, transition_smoothing, min_confidence.
+• Tests: Verify regime labels match visual regimes and that transition smoothing prevents flip-flop.
+
+44. regimeAwareWeightingRule
+
+• Logic: Adjust per-rule weights according to detected regime (e.g., up-weight trend rules in Trending regime).
+• Tunables: weights[regime][rule] (editable), weight_decay_rate.
+• Tests: Confirm weighting changes alter composite outputs as intended and improves historical regime-specific performance.
+
+45. compositeScoreRule
+
+• Logic: Compute weighted sum of enabled rule outputs → composite score; apply cooldown (bars or ATR retrace) before allowing retrigger.
+• Tunables: signal_threshold, cooldown_bars, cooldown_retrace_atr, min_rules_agree.
+• Tests: Ensure composite crosses threshold only when enough weighted support exists and cooldown prevents rapid reentries.
+
+46. conflictResolutionRule
+
+• Logic: When opposing signals appear within conflict window, net by composite score or default to neutral if within min_diff; apply hysteresis to avoid flip-flops.
+• Tunables: conflict_window_bars, min_diff, hysteresis_bars.
+• Tests: Simulate conflicting bursts and ensure resolution keeps higher conviction or returns neutral per configuration.
+
+47. duplicateSuppressionRule
+
+• Logic: Suppress repeated identical signals within a retrigger window unless composite rises by retrigger_delta to avoid redundant entries on same side.
+• Tunables: retrigger_window_bars, min_delta_retrigger, allow_partial_retrigger.
+• Tests: Verify duplicates suppressed and legitimate stronger re-signals allowed after min_delta_retrigger.
+
+Utils & Defaults (reminder)
+• Implement core indicators in /utils/indicators.js: SMA, EMA, RSI, ATR, VWAP, MACD, Bollinger, Stoch, OBV, bandwidth, ADX.
+• /config/defaults.json must contain safe out-of-box defaults for every tunable above so app works immediately.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,82 @@
+
+```markdown
+---
+project_name: banknifty-signals
+---
+
+# STATUS.md
+
+## Instructions for Updating
+- Update **date & time** and **% Complete** each time progress is made.
+- Mark tasks in **checklists**.
+- Add to **Change Log** for each commit/milestone.
+- Keep this file **in sync with Git history**.
+
+---
+
+## Project Status (Baseline)
+
+**Summary**: 
+**Last Updated**:  
+**% Complete**: 
+
+---
+
+### Phase Tracking update status as Pending/In Progress/Completed
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| Base Infrastructure | Docker, DB, Redis, migrations | ⬜  |
+| Zerodha Integration | OAuth, WS adapter, tokens | ⬜  |
+| Rules Engine | Implement all 47 rules | ⬜  |
+| Signal Generation | Composite signals, DB, WS | ⬜  |
+| Frontend Dashboard | Charts, rules, feed | ⬜  |
+| Backtesting | Modes, metrics, visualization | ⬜ |
+| Sentiment Module | API connectors, filters | ⬜  |
+| Observability & Tests | Prometheus, logging, CI/CD | ⬜ |
+
+---
+
+### Tasks: Sample update accordingly
+
+#### Completed ✅
+- [x] Production document reviewed.
+- [x] Documentation baseline (README, PLAN, RULES, STATUS).
+
+#### In Progress 🔄
+- [ ] Prepare initial Docker stack (backend + DB + Redis).
+- [ ] Configure Prisma/TypeORM schema.
+
+#### Pending ⬜
+- [ ] Zerodha KiteConnect adapter.
+- [ ] Implement rule modules (R001–R044).
+- [ ] Backtest engine with visualization.
+- [ ] Sentiment provider connectors.
+- [ ] Full CI/CD setup.
+
+---
+
+### Blockers
+- Zerodha API credentials required for live testing.
+- Decision pending: Prisma vs TypeORM (finalize ORM).
+
+---
+
+### Next Actions
+- Finalize DB ORM (Prisma/TypeORM).  
+- Implement **Base Infrastructure stage** (Docker + migrations).  
+- Prepare initial **unit tests** for indicators.
+
+---
+
+### Risks
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Zerodha API expiry (daily) | High | Auto-reconnect + prompt reauth |
+| OI data dependency | Medium | Graceful disable + UI status |
+| Backtest performance | Medium | Optimize queries + caching |
+
+---
+
+### Change Log
+- **2025-09-12**: Initial STATUS.md baseline created.  

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,0 +1,18 @@
+{
+  "adrPdrBreakoutRule": {
+    "adr_window": 14,
+    "pdr_lookback": 1,
+    "breakout_threshold_pct": 0.25,
+    "volume_multiplier": 1.5,
+    "false_breakout_filter_seconds": 120
+  },
+  "bollingerSqueezeRule": {
+    "band_length": 20,
+    "sigma": 2,
+    "squeeze_bandwidth_threshold_pct": 10,
+    "breakout_volume_multiplier": 1.5
+  },
+  "meta": {
+    "defaults_note": "These are safe example defaults. Tune per strategy and validate in backtests before using live. Values are illustrative."
+  }
+}

--- a/docs/rules/part-1.md
+++ b/docs/rules/part-1.md
@@ -1,0 +1,75 @@
+# Rules — Part 1 (1–12)
+
+This file contains rules 1 through 12 extracted from the main RULES.md.
+
+1. adrPdrBreakoutRule
+
+• Logic: Detect breakout above/below Average Daily Range (ADR) or Previous Day Range (PDR); confirm with directionally aligned volume before emitting 3/5/15m signals.
+• Tunables: adr_window, pdr_lookback, breakout_threshold_pct, volume_multiplier, false_breakout_filter_seconds.
+• Tests: Verify breakout > ADR/PDR triggers, volume confirms vs false-breakout scenario, rule fires correctly at 3/5/15m rollups.
+
+2. atrNormalizationRule
+
+• Logic: Scale/normalize raw price moves by ATR to make threshold decisions volatility-aware; produces normalized momentum contribution for 3/5/15m signals.
+• Tunables: atr_length, normalization_mode (percentile|zscore), adaptive_scaling_factor.
+• Tests: Validate normalized values stable across low/high ATR days and threshold mapping yields consistent signal rates.
+
+3. bollingerSqueezeRule
+
+• Logic: Detect low BB bandwidth (squeeze) and flag breakout when price closes outside bands with volume confirmation for intraday 3/5/15m signals.
+• Tunables: band_length, sigma, squeeze_bandwidth_threshold_pct, breakout_volume_multiplier.
+• Tests: Confirm squeeze→breakout chain triggers only after bandwidth threshold and volume confirms direction.
+
+4. breadthProxyRule
+
+• Logic: Use BankNifty constituency advance/decline percent and sector proxies as a breadth confirmation overlay to bias signals at 3/5/15m.
+• Tunables: breadth_window, min_pct_agree, divergence_threshold, regime_weighting.
+• Tests: Validate that when breadth > threshold, signals align with index; detect and flag divergence cases.
+
+5. breakRetestRule
+
+• Logic: After level breakout, wait for a retest within N bars; if retest rejects and volume supports, emit a follow-up 3/5/15m signal.
+• Tunables: retest_tolerance_pct, retest_bars, reentry_max_delay_seconds.
+• Tests: Simulate breakout then successful retest vs failed retest; confirm only successful retests trigger re-entry.
+
+6. cvdImbalanceRule
+
+• Logic: Detect cumulative volume delta (CVD) imbalance favoring buy or sell side and use as confirming filter for intraday signals.
+• Tunables: cvd_lookback, imbalance_z_threshold, smoothing_window.
+• Tests: Validate CVD leads/lags price moves, fire when CVD zscore > threshold and align with price direction.
+
+7. dynamicSRRule
+
+• Logic: Build dynamic support/resistance from recent swing pivots + liquidity clusters; treat break/rejection at these zones as signal events.
+• Tunables: pivot_window, cluster_sensitivity, min_cluster_volume, level_tolerance_pct.
+• Tests: Ensure levels detect real pivot zones, test break vs rejection outcomes and alignment with volume clusters.
+
+8. engulfingVolumeRule
+
+• Logic: Bullish/bearish engulfing candle validated by above-average volume z-score to trigger intraday signals on rollups.
+• Tunables: min_volume_ratio, body_to_wick_ratio, volume_z_len.
+• Tests: Compare pattern with/without volume filter; confirm only volume-confirmed engulfing produces signals.
+
+9. gapAnalysisRule
+
+• Logic: Classify overnight/opening gaps (continuation, exhaustion, fade) and apply rules to decide to follow or fade on morning 3/5/15m windows.
+• Tunables: gap_size_pct, min_open_drive_pct, fade_max_fill_pct, volume_confirmation.
+• Tests: Validate gap classification accuracy and that only matching continuation/exhaustion workflows trigger signals.
+
+10. hhhlLLlhRule
+
+• Logic: Detect structural patterns of HH/HL (bullish) or LL/LH (bearish) over recent pivots; bias intraday signals to structure direction.
+• Tunables: swing_window, min_pivot_distance_atr, min_legs.
+• Tests: Run sequences with synthetic pivots to confirm pattern detection and test suppression during choppy price action.
+
+11. insideBarRule
+
+• Logic: Detect inside bar(s) (single or multi) and trigger breakout signal when price breaks high/low with minimum body size and volume confirmation.
+• Tunables: ib_lookback_bars, min_body_fraction, volume_confirmation_z.
+• Tests: Validate inside bar breakout vs false breakout and ensure breakout fires on 3/5/15m aggregated bars.
+
+12. intradayCorrelationRule
+
+• Logic: Monitor short-term correlation between BANKNIFTY and NIFTY/sector components; down-weight or veto signals on strong negative divergence.
+• Tunables: correlation_window, correlation_threshold, divergence_hold_bars.
+• Tests: Confirm rule identifies correlation drops and that signals are flagged or de-weighted accordingly.

--- a/docs/rules/part-2.md
+++ b/docs/rules/part-2.md
@@ -1,0 +1,73 @@
+# Rules — Part 2 (13–24)
+
+13. ivCrushRule
+
+• Logic: Detect rapid implied volatility (IV) collapse after scheduled events and annotate signals (or reduce option-related signals) for intraday windows.
+• Tunables: iv_drop_pct, iv_lookback, event_cooldown_minutes.
+• Tests: Simulate IV drop events and confirm annotation, and that option/OI rules are suppressed or adjusted.
+
+14. liquidityGrabRule
+
+• Logic: Identify sharp price spike through liquidity cluster (wick through HVN) followed by quick reversal — classify as liquidity grab and issue contrarian signal if confirmed.
+• Tunables: wick_to_body_ratio, liquidity_cluster_sensitivity, max_reversion_bars.
+• Tests: Validate detection of liquidity grabs and confirm reversal probability vs random spikes.
+
+15. macdCrossRule
+
+• Logic: Use MACD line / signal cross with histogram momentum & optional volume to issue momentum-confirmed intraday signals on rollups.
+• Tunables: fast_len, slow_len, signal_len, min_hist_slope, volume_confirm.
+• Tests: Test cross with rising/falling histogram slope and ensure cross in chop is filtered.
+
+16. marketProfileRule
+
+• Logic: Derive POC/VAH/VAL from intraday profile; use value-area acceptance/rejection and POC changes as signal triggers on aggregated bars.
+• Tunables: profile_interval_minutes, value_area_pct, poc_sensitivity.
+• Tests: Confirm reactions at POC/VAH/VAL and ensure rejections produce expected signal behavior.
+
+17. marketThrustRule
+
+• Logic: Detect high-magnitude thrust moves (price + volume + momentum) and follow-through; emit trade signal when thrust crosses thresholds.
+• Tunables: thrust_threshold_pct, volume_multiplier, momentum_roc_len.
+• Tests: Validate thrust detection vs exhaustion and follow-through probability.
+
+18. meanReversionRule
+
+• Logic: Identify overextensions from short-term mean and emit contrarian intraday signals when reversion conditions + low regime volatility met.
+• Tunables: mean_len, deviation_threshold_pct, volatility_filter_atr.
+• Tests: Check reversion hits in range markets and suppressed firing in strong trends.
+
+19. momentumDivergenceRule
+
+• Logic: Detect divergence between momentum indicator (ROC/RSI) and price (new high/low) and use as reversal signal for intraday rollups.
+• Tunables: momentum_len, divergence_window, min_divergence_strength.
+• Tests: Validate detection of classic divergence and check false positives in sustained trends.
+
+20. momentumThresholdRule
+
+• Logic: Only allow signals when momentum metric exceeds threshold (filters weak momentum in chop) for 3/5/15m signals.
+• Tunables: momentum_metric, threshold_value, adaptive_scaling.
+• Tests: Ensure signals suppressed below threshold and allowed above, across varied vol days.
+
+21. openingRangeBreakoutRule
+
+• Logic: Use opening range (first N minutes) high/low break as trade trigger if breakout volume and subsequent follow-through confirm on aggregated bars.
+• Tunables: range_window_mins, breakout_threshold_pct, min_follow_through_bars.
+• Tests: Simulate ORB continuation vs false-breakout and confirm correct signal emission.
+
+22. optionFlowRule
+
+• Logic: Detect unusual option flow (large notional, directional call/put buys) and bias underlying intraday signals when flow correlates with price.
+• Tunables: min_notional, time_window_secs, flow_bias_confidence.
+• Tests: Validate that large flows precede directional moves and rule annotates/weights signals accordingly.
+
+23. optionGreeksRule
+
+• Logic: Monitor aggregated Greeks exposure (gamma/vega) that indicate sensitivity to underlying moves and adjust option-sensitive signals intraday.
+• Tunables: greek_thresholds (gamma, vega), exposure_window.
+• Tests: Ensure rule flags high gamma/vega periods and that option-flow signals adapt.
+
+24. orderflowDeltaRule
+
+• Logic: Use net orderflow delta (buy vs sell prints) to bias or confirm signals — emit when delta normalized over lookback exceeds threshold.
+• Tunables: delta_threshold, normalization_window, smoothing.
+• Tests: Confirm delta leads price moves and that normalized delta above threshold raises confidence.

--- a/docs/rules/part-3.md
+++ b/docs/rules/part-3.md
@@ -1,0 +1,73 @@
+# Rules — Part 3 (25–36)
+
+25. preMarketMomentumRule
+
+• Logic: Capture pre-market futures/early session momentum and bias first-hour intraday signals consistent with that pre-open trend.
+• Tunables: premarket_window_minutes, min_premarket_move_pct, apply_for_bars.
+• Tests: Validate premarket move predictive power for open + early intraday signals.
+
+26. roundNumberMagnetRule
+
+• Logic: Treat round strike/price levels as magnet/support-resistance; generate bounce or breakout signals when price approaches and reacts within tolerance.
+• Tunables: round_interval, tolerance_pct, reaction_window_bars.
+• Tests: Measure bounce vs break frequency at levels and validate event triggers.
+
+27. rsiAdaptiveRule
+
+• Logic: Adjust RSI overbought/oversold thresholds dynamically based on volatility regime (ATR); emit signals when adaptive thresholds crossed.
+• Tunables: rsi_len, base_upper, base_lower, volatility_adjustment_factor.
+• Tests: Check threshold shifting by ATR and verify stable signal count across regimes.
+
+28. sectorRotationRule
+
+• Logic: Use relative strength of Bank sector vs broader market or constituents to bias or suppress intraday signals.
+• Tunables: sector_window, rotation_threshold, weighting_mode.
+• Tests: Validate detection of sector rotation and that biases improve directional accuracy.
+
+29. spreadGuardRule
+
+• Logic: Detect wide bid-ask spreads and down-weight or block signals to avoid poor execution.
+• Tunables: max_spread_ticks, min_liquidity_volume, action (block|downweight).
+• Tests: Simulate wide spread scenarios and ensure signals are blocked or lowered in confidence.
+
+30. stochasticRule
+
+• Logic: Use Stochastic %K/%D crossings in context of trend to issue intraday entries at 3/5/15m when confluence present.
+• Tunables: k_len, d_len, overbought, oversold, trend_filter.
+• Tests: Validate cross triggers in trend vs range and false positive suppression.
+
+31. supertrendRule
+
+• Logic: Use SuperTrend flips (ATR-based) for directional bias and first-pullback entries on flip; issue signals at rollups.
+• Tunables: atr_len, multiplier, pullback_depth_atr.
+• Tests: Confirm flip detection and test pullback entries after flip.
+
+32. swingBreakRule
+
+• Logic: Detect clean break of recent swing high/low with confirmation volume and momentum for intraday rollout signals.
+• Tunables: swing_window, min_confirm_volume_z, momentum_confirm_len.
+• Tests: Validate swing-break success rate and avoid fake-break filter.
+
+33. threeBarThrustRule
+
+• Logic: Detect 3-bar thrust (consecutive strong closes with increasing range) and follow on momentum for intraday trades.
+• Tunables: bars=3, min_range_growth_pct, vol_filter_z.
+• Tests: Confirm pattern detection and test continuation vs exhaustion.
+
+34. timePatternRule
+
+• Logic: Identify repeating intraday time-of-day patterns (e.g., end-of-hour liquidity moves) and bias signals when pattern matched.
+• Tunables: session_window, pattern_library, match_confidence.
+• Tests: Verify repeatability across multiple sessions and correct detection of pattern-triggered signal bias.
+
+35. trendHTFRule
+
+• Logic: Use higher timeframe trend (5/15/60m) to bias 3/5/15m signals — require HTF confluence for higher conviction.
+• Tunables: htf_windows, confluence_required_count, htf_weight.
+• Tests: Multi-timeframe confluence tests and suppression when HTF disagrees.
+
+36. trendlineBreakRule
+
+• Logic: Auto-fit trendlines to pivots; signal on confirmed breakout with min touchpoints and volume confirmation at 3/5/15m.
+• Tunables: min_touch_points, break_buffer_pct, min_break_volume_z.
+• Tests: Differentiate valid trendline breaks vs false ones and confirm volume requirement prevents fakes.

--- a/docs/rules/part-4.md
+++ b/docs/rules/part-4.md
@@ -1,0 +1,71 @@
+# Rules — Part 4 (37–47 + Utils)
+
+37. volatilityExpansionRule
+
+• Logic: Detect sudden volatility expansion (ATR or BB width jump) that often precedes directional moves and trigger momentum-follow signals.
+• Tunables: expansion_threshold_pct, vol_window, min_follow_through_bars.
+• Tests: Confirm expansions precede directional moves and test signal timing after expansion.
+
+38. volumeBalanceRule
+
+• Logic: Compare buy vs sell volume balance; emit signals when imbalance sustained and aligns with price action on rollups.
+• Tunables: balance_threshold_pct, normalization_window, smoothing.
+• Tests: Validate imbalance lead/lag and alignment with price movement.
+
+39. volumeClimaxRule
+
+• Logic: Detect volume climax (extreme volume zscore) often indicating exhaustion or start of thrust; classify as reversal or continuation based on context.
+• Tunables: climax_z_threshold, relative_vol_window, post_climax_window.
+• Tests: Validate exhaustion vs continuation labeling and subsequent price behavior.
+
+40. volumeProfileRule
+
+• Logic: Use intraday volume profile HVN/LVN to detect rejections or breakouts and trigger signals when price interacts with profile levels.
+• Tunables: profile_window_mins, hvn_lvn_threshold, rejection_confirmation_bars.
+• Tests: Confirm bounce/rejection at HVN/LVN and measure signal hit rates.
+
+41. vwapBiasRule
+
+• Logic: Use session VWAP and bands; emit BUY when price sustained above VWAP band and SELL when below, with rollup confirmations.
+• Tunables: vwap_band_sigma, sustain_bars_required, vwap_timeout_minutes.
+• Tests: Check bounce/rejection stats at VWAP and that sustaining above/below band increases confidence.
+
+42. wickRejectionRule
+
+• Logic: Detect strong wick rejection from key level (long tail with close away) and emit contrarian intraday signals when supported by volume.
+• Tunables: wick_to_body_ratio, key_level_filter, min_volume_z.
+• Tests: Validate rejection leads to reversal for a high % and ensure rule suppressed in low-volume contexts.
+
+43. regimeDetectionRule
+
+• Logic: Classify market regime (Trending / Range / Mean-Revert) using volatility, H/L overlap, ADX, BB bandwidth and recent breakout success rate; smooth transitions.
+• Tunables: regime_window, feature_set, transition_smoothing, min_confidence.
+• Tests: Verify regime labels match visual regimes and that transition smoothing prevents flip-flop.
+
+44. regimeAwareWeightingRule
+
+• Logic: Adjust per-rule weights according to detected regime (e.g., up-weight trend rules in Trending regime).
+• Tunables: weights[regime][rule] (editable), weight_decay_rate.
+• Tests: Confirm weighting changes alter composite outputs as intended and improves historical regime-specific performance.
+
+45. compositeScoreRule
+
+• Logic: Compute weighted sum of enabled rule outputs → composite score; apply cooldown (bars or ATR retrace) before allowing retrigger.
+• Tunables: signal_threshold, cooldown_bars, cooldown_retrace_atr, min_rules_agree.
+• Tests: Ensure composite crosses threshold only when enough weighted support exists and cooldown prevents rapid reentries.
+
+46. conflictResolutionRule
+
+• Logic: When opposing signals appear within conflict window, net by composite score or default to neutral if within min_diff; apply hysteresis to avoid flip-flops.
+• Tunables: conflict_window_bars, min_diff, hysteresis_bars.
+• Tests: Simulate conflicting bursts and ensure resolution keeps higher conviction or returns neutral per configuration.
+
+47. duplicateSuppressionRule
+
+• Logic: Suppress repeated identical signals within a retrigger window unless composite rises by retrigger_delta to avoid redundant entries on same side.
+• Tunables: retrigger_window_bars, min_delta_retrigger, allow_partial_retrigger.
+• Tests: Verify duplicates suppressed and legitimate stronger re-signals allowed after min_delta_retrigger.
+
+Utils & Defaults (reminder)
+• Implement core indicators in /utils/indicators.js: SMA, EMA, RSI, ATR, VWAP, MACD, Bollinger, Stoch, OBV, bandwidth, ADX.
+• /config/defaults.json must contain safe out-of-box defaults for every tunable above so app works immediately.


### PR DESCRIPTION
Split RULES.md into docs/rules/part-*.md and added config/defaults.json with example tunables. Improves navigability and contributor onboarding.