### PR TITLE
test(ci): add /health smoke test and rulesEngine init tests

### DIFF
--- a/tests/integration/health.smoke.test.ts
+++ b/tests/integration/health.smoke.test.ts
@@ -1,0 +1,17 @@
+import http from 'http';
+import axios from 'axios';
+
+// Very small smoke test that performs an HTTP GET /health against the running app.
+// In CI the infra-validation workflow starts the backend and waits for tcp:8080; this test
+// helps ensure that the HTTP endpoint returns 200 at the app level.
+
+describe('Smoke: /health', () => {
+  jest.setTimeout(30_000);
+
+  test('GET /health returns 200', async () => {
+    const res = await axios.get('http://localhost:8080/health', { timeout: 5000 });
+    expect(res.status).toBe(200);
+    // Optionally assert a JSON body exists
+    expect(res.data).toBeDefined();
+  });
+});

--- a/tests/unit/rulesEngine.init.test.ts
+++ b/tests/unit/rulesEngine.init.test.ts
@@ -1,0 +1,50 @@
+import { jest } from '@jest/globals';
+
+// Minimal unit tests for RulesEngine initialization paths.
+// We'll mock environment and any external dependencies to ensure the initialization
+// code doesn't throw and chooses the right path when ENABLE_RULES_ENGINE is set.
+
+describe('RulesEngine initialization', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // clear module cache
+    process.env = { ...OLD_ENV };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  test('does not initialize when ENABLE_RULES_ENGINE is not set', async () => {
+    delete process.env.ENABLE_RULES_ENGINE;
+
+    // Import index after env change to ensure module picks up env
+    const index = await import('../../backend/src/index');
+
+    // Expect index.start to be a function and not to throw when called
+    expect(typeof index.start).toBe('function');
+
+    // calling start should return a Promise (but we won't actually start server)
+    const startPromise = index.start();
+    // allow it to run briefly and then abort if it tries to bind; we only assert no immediate rejection
+    await expect(Promise.race([startPromise, Promise.resolve('ok')])).resolves.not.toBe('ok');
+  });
+
+  test('initialization path when ENABLE_RULES_ENGINE=true does not crash on missing dependencies', async () => {
+    process.env.ENABLE_RULES_ENGINE = 'true';
+
+    // Mock createAppConnection to prevent TypeORM from actually connecting
+    jest.unstable_mockModule('../../backend/src/db', () => ({
+      createAppConnection: async () => ({ isMock: true })
+    }));
+
+    const index = await import('../../backend/src/index');
+
+    // Starting should not throw synchronously
+    expect(typeof index.start).toBe('function');
+
+    // Call start but don't wait for full server lifecycle; just ensure it doesn't throw
+    await expect(Promise.resolve().then(() => index.start())).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/rulesEngine.init.test.ts
+++ b/tests/unit/rulesEngine.init.test.ts
@@ -1,8 +1,7 @@
-import { jest } from '@jest/globals';
-
 // Minimal unit tests for RulesEngine initialization paths.
-// We'll mock environment and any external dependencies to ensure the initialization
-// code doesn't throw and chooses the right path when ENABLE_RULES_ENGINE is set.
+// Keep tests lightweight: only assert that the exported `start` function exists and that
+// importing the module doesn't throw. We avoid calling `start()` here because it
+// performs DB/Redis connections and starts the HTTP server.
 
 describe('RulesEngine initialization', () => {
   const OLD_ENV = process.env;
@@ -16,35 +15,15 @@ describe('RulesEngine initialization', () => {
     process.env = OLD_ENV;
   });
 
-  test('does not initialize when ENABLE_RULES_ENGINE is not set', async () => {
+  test('module exposes start function when ENABLE_RULES_ENGINE not set', async () => {
     delete process.env.ENABLE_RULES_ENGINE;
-
-    // Import index after env change to ensure module picks up env
     const index = await import('../../backend/src/index');
-
-    // Expect index.start to be a function and not to throw when called
     expect(typeof index.start).toBe('function');
-
-    // calling start should return a Promise (but we won't actually start server)
-    const startPromise = index.start();
-    // allow it to run briefly and then abort if it tries to bind; we only assert no immediate rejection
-    await expect(Promise.race([startPromise, Promise.resolve('ok')])).resolves.not.toBe('ok');
   });
 
-  test('initialization path when ENABLE_RULES_ENGINE=true does not crash on missing dependencies', async () => {
+  test('module exposes start function when ENABLE_RULES_ENGINE=true', async () => {
     process.env.ENABLE_RULES_ENGINE = 'true';
-
-    // Mock createAppConnection to prevent TypeORM from actually connecting
-    jest.unstable_mockModule('../../backend/src/db', () => ({
-      createAppConnection: async () => ({ isMock: true })
-    }));
-
     const index = await import('../../backend/src/index');
-
-    // Starting should not throw synchronously
     expect(typeof index.start).toBe('function');
-
-    // Call start but don't wait for full server lifecycle; just ensure it doesn't throw
-    await expect(Promise.resolve().then(() => index.start())).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
Adds a lightweight smoke test asserting GET /health returns 200 (used by CI) and lightweight unit tests checking start module export for RulesEngine initialization paths. This PR targets feature branch eature/rules-engine-scaffold and links Issue #23 (coverage).